### PR TITLE
BOOK-1196: Navigation Fix and Refactoring

### DIFF
--- a/src/components/App/TitleBar/SportsbookToggle.jsx
+++ b/src/components/App/TitleBar/SportsbookToggle.jsx
@@ -1,6 +1,7 @@
 import React, {PureComponent} from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
+import {withRouter} from 'react-router';
 import PropTypes from 'prop-types';
 import {AppActions, NavigateActions} from '../../../actions';
 import {I18n} from 'react-redux-i18n';
@@ -16,6 +17,7 @@ class SportsbookToggle extends PureComponent {
 
   toggle(mode) {
     let subroute = '';
+    let path = '/exchange';
 
     if (this.props.sportID) {
       subroute = '/sport/' + this.props.sportID;
@@ -27,22 +29,12 @@ class SportsbookToggle extends PureComponent {
       subroute = '/BettingMarketGroup/' + this.props.bmgID;
     }
 
-    switch (mode) {
-      case BookieModes.EXCHANGE: {
-        this.props.setMode(BookieModes.EXCHANGE);
-        this.props.navigateTo('/exchange' + subroute);
-        break;
-      }
-
-      case BookieModes.SPORTSBOOK: {
-        this.props.setMode(BookieModes.SPORTSBOOK);
-        this.props.navigateTo('/sportsbook' + subroute);
-        break;
-      }
-
-      default:
-        break;
+    if (mode === BookieModes.SPORTSBOOK) {
+      path = '/sportsbook';
     }
+
+    this.props.navigateTo(path + subroute);
+
   }
 
   render() {
@@ -72,9 +64,18 @@ SportsbookToggle.propTypes = {
   navigateTo: PropTypes.func,
 };
 
-const mapStateToProps = (state) => {
+const mapStateToProps = (state, ownProps) => {
   const previousRoute = state.getIn(['routing', 'locationBeforeTransitions']);
   let sportID, eventGroupID, eventID, bmgID;
+
+  const marketDrawerPaths = ['bettingmarketgroup', 'events'];
+  // Determine which betting drawer we should check
+  let path = ['marketDrawer', 'unconfirmedBets'];
+  const transitionName = ownProps.location.pathname.split('/');
+
+  if (transitionName.length < 3 || !marketDrawerPaths.includes(transitionName[2].toLowerCase())) {
+    path = ['quickBetDrawer', 'bets'];
+  }
 
   // If the previous route exists
   if (previousRoute) {
@@ -113,6 +114,7 @@ const mapStateToProps = (state) => {
     bookMode: state.getIn(['app', 'bookMode']),
     previousRoute: state.getIn(['routing', 'previousRoute']),
     sportID, eventGroupID, eventID, bmgID,
+    hasUnplacedBets: !state.getIn(path).isEmpty(),
   };
 };
 
@@ -126,7 +128,7 @@ const mapDispatchToProps = (dispatch) => {
   );
 };
 
-export default connect(
+export default withRouter(connect(
   mapStateToProps,
   mapDispatchToProps
-)(SportsbookToggle);
+)(SportsbookToggle));

--- a/src/components/Exchange/Exchange.jsx
+++ b/src/components/Exchange/Exchange.jsx
@@ -16,6 +16,10 @@ import UnplacedBetModal from '../Modal/UnplacedBetModal';
 import Ps from 'perfect-scrollbar';
 import CommonMessage from '../CommonMessage/CommonMessage';
 import CommonMessageActions from '../../actions/CommonMessageActions';
+import AppActions from '../../actions/AppActions';
+import BookieModes from '../../constants/BookieModes';
+
+let nextPathName;
 
 class Exchange extends PureComponent {
   constructor(props) {
@@ -76,7 +80,7 @@ class Exchange extends PureComponent {
    * Situations could be
    *   - leaving without unconfirmed bets.
    *   - leaving after clicking confirm button in modal when there is unconfirmed bets.
-   *
+   * 
    * Attempts to reset the store about unconfirmed bets as well as state of UI like modal 
    * visibliity and overlay.
    */
@@ -87,6 +91,13 @@ class Exchange extends PureComponent {
     this.props.clearMarketBetsOverlay();
 
     this.setModalVisible(false);
+
+    if (nextPathName[1] === BookieModes.SPORTSBOOK) {
+      this.props.setMode(BookieModes.SPORTSBOOK);
+    } else if (nextPathName[1] === BookieModes.EXCHANGE) {
+      this.props.setMode(BookieModes.EXCHANGE);
+    }
+
     this.setState({
       confirmToLeave: true
     });
@@ -114,6 +125,8 @@ class Exchange extends PureComponent {
     this.setState({
       nextLocation
     });
+
+    nextPathName = nextLocation.pathname.split('/');
 
     if (
       !this.props.isShowLogoutPopup &&
@@ -233,7 +246,8 @@ const mapDispatchToProps = (dispatch) => bindActionCreators(
     clearQuickBetsOverlay: QuickBetDrawerActions.hideOverlay,
     clearMarketDrawerBetslips: MarketDrawerActions.deleteAllUnconfirmedBets,
     clearMarketBetsOverlay: MarketDrawerActions.hideOverlay,
-    addCommonMessage: CommonMessageActions.newMessage
+    addCommonMessage: CommonMessageActions.newMessage,
+    setMode: AppActions.setBookMode,
   },
   dispatch
 );

--- a/src/components/Exchange/Exchange.jsx
+++ b/src/components/Exchange/Exchange.jsx
@@ -209,11 +209,12 @@ const mapStateToProps = (state, ownProps) => {
     state.getIn(['setting', 'settingByAccountId', accountId]) ||
     state.getIn(['setting', 'defaultSetting']);
   const currencyFormat = setting.get('currencyFormat');
+  const marketDrawerPaths = ['bettingmarketgroup', 'events'];
   // Determine which betting drawer we should check
   let path = ['marketDrawer', 'unconfirmedBets'];
   const transitionName = ownProps.location.pathname.split('/');
 
-  if (transitionName.length < 3 || transitionName[2].toLowerCase() !== 'bettingmarketgroup') {
+  if (transitionName.length < 3 || !marketDrawerPaths.includes(transitionName[2].toLowerCase())) {
     path = ['quickBetDrawer', 'bets'];
   }
 


### PR DESCRIPTION
Addresses 1196:

> "Confirm Navigation" pop-up thrown on navigating out of events page

In addition , the toggle function has been refactored. The toggle function will no longer directly control the state responsible for Bookie's mode. This has been moved into the routing, this solves a few edge case unintended side effects of the old functionality.